### PR TITLE
Display rework

### DIFF
--- a/src/chip8.c
+++ b/src/chip8.c
@@ -62,6 +62,11 @@ void cycle(CHIP8 *cpu)
         u16 opcode = fetch_opcode(cpu);
         decode(cpu, opcode);
 
+        if (cpu->drawFlag == 1)
+        {
+            renderToScreen(cpu);
+        }
+
         if (cpu->delayTimer > 0)
         {
             cpu->delayTimer--;
@@ -114,15 +119,13 @@ void decode(CHIP8 *cpu, u16 opcode)
     u8 y = (opcode & 0x00F0) >> 4;
     u8 kk = opcode & 0x00FF;
 
-    u8 sprite[n];
-
     switch (firstNibble)
     {
     case 0:
         // 00E0 - CLS
         if (opcode == 0x00E0)
         {
-            cls();
+            cls(cpu);
         }
         // 00EE - RET
         else if (opcode == 0x00EE)
@@ -248,12 +251,7 @@ void decode(CHIP8 *cpu, u16 opcode)
         break;
     case 0xD:
         // Dxyn - DRW Vx, Vy, nibble
-        VF = 0;
-        for (size_t i = 0; i < n; i++)
-        {
-            sprite[i] = read_u8(cpu, cpu->i + (u16)i);
-        }
-        VF = drawSprite(sprite, n, Vx, Vy);
+        drawSprite(cpu, n, Vx, Vy);
         break;
     case 0xE:
         // Ex9E - SKP Vx

--- a/src/chip8.c
+++ b/src/chip8.c
@@ -23,6 +23,7 @@ CHIP8 *CHIP8_new(u8 *rom, long romSize)
     memset(cpu->v, 0, sizeof(cpu->v));
     memset(cpu->stack, 0, sizeof(cpu->stack));
     memset(cpu->display, 0, sizeof(cpu->display));
+    cpu->drawFlag = 0;
 
     // TODO: init sound
     cpu->delay_timer = 0;

--- a/src/chip8.c
+++ b/src/chip8.c
@@ -18,11 +18,12 @@ CHIP8 *CHIP8_new(u8 *rom, long romSize)
 {
     // For Cxkk
     srand(time(NULL));
-
-    CHIP8 *cpu = calloc(61, sizeof(u8));
+    CHIP8 *cpu = calloc(sizeof(*cpu), sizeof(u8));
     cpu->ram = calloc(4096, sizeof(u8));
     memset(cpu->v, 0, sizeof(cpu->v));
     memset(cpu->stack, 0, sizeof(cpu->stack));
+    memset(cpu->display, 0, sizeof(cpu->display));
+
     // TODO: init sound
     cpu->delay_timer = 0;
 

--- a/src/chip8.c
+++ b/src/chip8.c
@@ -1,6 +1,5 @@
 #include <stdlib.h>
 #include <string.h>
-#include <sys/time.h>
 #include <time.h>
 #include <unistd.h>
 #include <math.h>
@@ -54,14 +53,8 @@ void CHIP8_destroy(CHIP8 *cpu)
 
 void cycle(CHIP8 *cpu)
 {
-    struct timeval t1, t2;
-    double elapsedTime;
-
     while (1)
     {
-        // start timer
-        gettimeofday(&t1, NULL);
-
         if (handleUserInterrupt() == 1)
         {
             break;
@@ -69,24 +62,11 @@ void cycle(CHIP8 *cpu)
         u16 opcode = fetch_opcode(cpu);
         decode(cpu, opcode);
 
-        // end timer
-        gettimeofday(&t2, NULL);
-        elapsedTime = (t2.tv_sec - t1.tv_sec) * 1000.0;
-
-        // decrease delay timer by 1 each 16.(6) ms if > 0
         if (cpu->delay_timer > 0)
         {
-            int amountToReduce = (int)floor(elapsedTime / 16.7);
-            if (cpu->delay_timer > amountToReduce)
-            {
-                cpu->delay_timer -= amountToReduce;
-            }
-            else
-            {
-                cpu->delay_timer = 0;
-            }
+            cpu->delay_timer--;
         }
-        // sleep(1);
+        usleep(1000);
     }
 }
 

--- a/src/chip8.c
+++ b/src/chip8.c
@@ -25,7 +25,7 @@ CHIP8 *CHIP8_new(u8 *rom, long romSize)
     cpu->drawFlag = 0;
 
     // TODO: init sound
-    cpu->delay_timer = 0;
+    cpu->delayTimer = 0;
 
     SP = 0;
     PC = 0x0200;
@@ -62,9 +62,9 @@ void cycle(CHIP8 *cpu)
         u16 opcode = fetch_opcode(cpu);
         decode(cpu, opcode);
 
-        if (cpu->delay_timer > 0)
+        if (cpu->delayTimer > 0)
         {
-            cpu->delay_timer--;
+            cpu->delayTimer--;
         }
         usleep(1000);
     }
@@ -282,7 +282,7 @@ void decode(CHIP8 *cpu, u16 opcode)
         {
         // Fx07 - LD Vx, DT
         case 0x07:
-            Vx = cpu->delay_timer;
+            Vx = cpu->delayTimer;
             break;
         // LD Vx, K
         case 0x0A:
@@ -290,7 +290,7 @@ void decode(CHIP8 *cpu, u16 opcode)
             break;
         // Fx15 - LD DT, Vx
         case 0x15:
-            cpu->delay_timer = Vx;
+            cpu->delayTimer = Vx;
             break;
         case 0x18:
             // TODO: sound

--- a/src/chip8.h
+++ b/src/chip8.h
@@ -38,7 +38,7 @@ typedef struct Chip8
     u8 v[16]; // 16 general purpose 8-bit registers
     u16 i;    // 16-bit registers general used to store adresses so only the lowest (rightmost) 12 bits are usually used
     // TODO: delay + sound registers
-    u8 delay_timer;
+    u8 delayTimer;
     u16 pc; // program counter
     u8 sp;  // stack pointer
     u8 drawFlag;

--- a/src/chip8.h
+++ b/src/chip8.h
@@ -41,6 +41,7 @@ typedef struct Chip8
     u8 delay_timer;
     u16 pc; // program counter
     u8 sp;  // stack pointer
+    u8 drawFlag;
 } CHIP8;
 
 /// @brief CHIP-8's common built-in font. Stored in 0x50 - 0x9F

--- a/src/chip8.h
+++ b/src/chip8.h
@@ -34,6 +34,7 @@ typedef struct Chip8
     // +---------------+= 0x000 (0) Start of Chip-8 RAM
     u8 *ram;
     u16 stack[16];
+    u8 display[64][32];
     u8 v[16]; // 16 general purpose 8-bit registers
     u16 i;    // 16-bit registers general used to store adresses so only the lowest (rightmost) 12 bits are usually used
     // TODO: delay + sound registers

--- a/src/graphics.h
+++ b/src/graphics.h
@@ -4,6 +4,8 @@
 #include <stdint.h>
 #include <SDL2/SDL.h>
 
+#include "chip8.h"
+
 #define SCALE 10
 
 static const SDL_Scancode scancodeMap[16] = {
@@ -20,9 +22,9 @@ static const SDL_Scancode scancodeMap[16] = {
     SDL_SCANCODE_Z,
     SDL_SCANCODE_C,
     SDL_SCANCODE_4,
-    SDL_SCANCODE_D,
-    SDL_SCANCODE_E,
+    SDL_SCANCODE_R,
     SDL_SCANCODE_F,
+    SDL_SCANCODE_V,
 };
 
 typedef uint8_t u8;

--- a/src/graphics.h
+++ b/src/graphics.h
@@ -32,9 +32,11 @@ void initSDL(void);
 
 void destroySDL(void);
 
-void cls(void);
+void cls(CHIP8 *cpu);
 
-u8 drawSprite(u8 *sprite, u8 n, u8 x, u8 y);
+void drawSprite(CHIP8 *cpu, u8 n, u8 x, u8 y);
+
+void renderToScreen(CHIP8 *cpu);
 
 int getKeyboardState(u8 key);
 


### PR DESCRIPTION
The old displaying method using only SDL_Texture to keep track of screen states doesn't work.
Add an internal 2d array inside CHIP8 to store states instead, after each 00E0 or Dxyn the array will be rendered to the screen. 